### PR TITLE
🚨 Get rid of warning saying copy is done with potential overflow

### DIFF
--- a/src/NetTcpJson/Extractor.cpp
+++ b/src/NetTcpJson/Extractor.cpp
@@ -40,6 +40,7 @@ bool Extractor::extract(const std::uint8_t* buffer, const std::size_t& length)
     if(!_lastBuffer.empty())
     {
         tempData = _lastBuffer;
+        _lastBuffer.clear();
         tempData.insert(tempData.end(), buffer, buffer + length);
 
         realBuffer = tempData.data();

--- a/src/NetTcpJson/Extractor.cpp
+++ b/src/NetTcpJson/Extractor.cpp
@@ -39,8 +39,8 @@ bool Extractor::extract(const std::uint8_t* buffer, const std::size_t& length)
     // Let's create a copy buffer of current buffer and last
     if(!_lastBuffer.empty())
     {
-        tempData = std::move(_lastBuffer);
-        tempData.insert(std::end(tempData), buffer, buffer + length);
+        tempData = _lastBuffer;
+        tempData.insert(tempData.end(), buffer, buffer + length);
 
         realBuffer = tempData.data();
         realLength = tempData.size();


### PR DESCRIPTION
```
warning: 'void* __builtin_memcpy(void*, const void*, long unsigned int)'
writing between 2 and 9223372036854775807 bytes into a region of size 0
overflows the destination [-Wstringop-overflow=]
  437 |             __builtin_memmove(__result, __first, sizeof(_Tp) *
_Num);
```

This bring a copy instead of a move, but whatever this shouldn't occurring often anyway